### PR TITLE
fix: re-assert AFK state on gateway reconnect

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -172,6 +172,16 @@ export default definePlugin({
         }
     ],
 
+    flux: {
+        CONNECTION_OPEN() {
+            const alwaysSend = Settings.plugins.WayAFKNext.alwaysSendPushNotifications;
+            if (alwaysSend) {
+                if (debug) console.log("[WayAFKNext] Gateway reconnected, re-asserting AFK state");
+                utilSetDiscordAFK(true);
+            }
+        }
+    },
+
     async start() {
         await setDebug(Settings.plugins.WayAFKNext.debug);
 


### PR DESCRIPTION
## Summary
- When Discord's gateway reconnects (e.g. after a network interruption or server-side restart), the AFK state is silently cleared, causing "Always send push notifications" to stop working until the user manually re-toggles the setting
- This adds a `flux` handler for `CONNECTION_OPEN` that automatically re-asserts the AFK state after reconnection, so push notifications continue working without user intervention

## Test plan
- [x] Verified fix via compiled renderer patch before implementing in source
- [ ] Enable "Always send push notifications", wait for a gateway reconnect (or force one by toggling network), confirm AFK state is re-asserted and push notifications continue